### PR TITLE
Remove targets and detect the build system automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ The build scripts for each project:
   3. Create a `cmake_build` directory in the worker directory
   4. Invoke `cmake` with arguments depending on the target platform
 
-To build and launch a local deployment execute the following commands. The
-target platform is one of `windows`, `linux` or `macos`. Set it based on your
-development environment:
+To build and launch a local deployment execute the following commands:
 
 ```
-spatial worker build --target=<platform>
+spatial worker build
 spatial local launch
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e -u -x -o pipefail
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  cmake .. -DCMAKE_C_FLAGS=-m64 -G "Unix Makefiles"
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+  cmake .. -DCMAKE_OSX_ARCHITECTURES=x86_64 -G "Unix Makefiles"
+else
+  cmake .. -DCMAKE_GENERATOR_PLATFORM=x64
+fi

--- a/workers/External/build.json
+++ b/workers/External/build.json
@@ -44,34 +44,10 @@
         {
           "name": "CMake build",
           "working_path": "cmake_build",
-          "command": "cmake",
+          "command": "bash",
           "arguments": [
-            "-DCMAKE_GENERATOR_PLATFORM=x64",
-            ".."
-          ],
-          "target": "windows"
-        },
-        {
-          "name": "CMake build",
-          "working_path": "cmake_build",
-          "command": "cmake",
-          "arguments": [
-            "-DCMAKE_C_FLAGS=-m64",
-            "-G", "Unix Makefiles",
-            ".."
-          ],
-          "target": "linux"
-        },
-        {
-          "name": "CMake build",
-          "working_path": "cmake_build",
-          "command": "cmake",
-          "arguments": [
-            "-DCMAKE_OSX_ARCHITECTURES=x86_64",
-            "-G", "Unix Makefiles",
-            ".."
-          ],
-          "target": "macos"
+            "../../../build.sh"
+          ]
         },
         {
           "name": "Zip worker",

--- a/workers/Managed/build.json
+++ b/workers/Managed/build.json
@@ -44,34 +44,10 @@
         {
           "name": "CMake build",
           "working_path": "cmake_build",
-          "command": "cmake",
+          "command": "bash",
           "arguments": [
-            "-DCMAKE_GENERATOR_PLATFORM=x64",
-            ".."
-          ],
-          "target": "windows"
-        },
-        {
-          "name": "CMake build",
-          "working_path": "cmake_build",
-          "command": "cmake",
-          "arguments": [
-            "-DCMAKE_C_FLAGS=-m64",
-            "-G", "Unix Makefiles",
-            ".."
-          ],
-          "target": "linux"
-        },
-        {
-          "name": "CMake build",
-          "working_path": "cmake_build",
-          "command": "cmake",
-          "arguments": [
-            "-DCMAKE_OSX_ARCHITECTURES=x86_64",
-            "-G", "Unix Makefiles",
-            ".."
-          ],
-          "target": "macos"
+            "../../../build.sh"
+          ]
         },
         {
           "name": "Zip worker",


### PR DESCRIPTION
Removes the need to specify a build target and avoids some compilation issues.