### PR TITLE
Documenting required flag runtime_version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ To build and launch a local deployment execute the following commands:
 
 ```
 spatial worker build
-spatial local launch
+spatial local launch --runtime_version=<runtime version>
+```
+
+You can get a list of supported runtime versions by running
+
+```
+spatial runtime list-supported-versions
 ```
 
 To connect a new instance of the "External" worker type to a running local deployment (after `spatial local launch`):

--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ To build and launch a local deployment execute the following commands:
 
 ```
 spatial worker build
-spatial local launch --runtime_version=<runtime version>
-```
-
-You can get a list of supported runtime versions by running
-
-```
-spatial runtime list-supported-versions
+spatial local launch --runtime_version=14.5.4
 ```
 
 To connect a new instance of the "External" worker type to a running local deployment (after `spatial local launch`):


### PR DESCRIPTION
# Problem
When following the steps required to build and launch worker locally, I get an error due to a required flag missing


```bash
$ spatial local launch                   
Encountered an error during command execution.
could not start deployment - runtime version must be provided.
```

# Changes
This PR documents the need for that flag and sets a sensible value