### PR TITLE
Add note to use bash shell for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ spatial local launch --runtime_version=14.5.4
 
 > **Windows users**
 >
-> It is strongly recommended that you invoke `spatial worker build` directly from a bash shell, e.g. git bash. The command executes shell scripts internally, which are likely to fail when invoked from other types of shells (e.g. cmder).
-> Likely issues when not using a bash shell are the `$'\r': command not found` error, or the `cmake` command not being found.
+> If you have [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) installed, it is strongly recommended that you invoke `spatial worker build` directly from a non-WSL bash shell, e.g. git bash. The command executes shell scripts internally, which are likely to fail when invoked from other types of shells (e.g. cmder, powershell).
+> Try this if you see the `$'\r': command not found` error, or the `cmake` command not getting found despite being installed.
 
 To connect a new instance of the "External" worker type to a running local deployment (after `spatial local launch`):
 


### PR DESCRIPTION
When invoking `spatial worker build` from e.g. cmder, the internal invocations of `bash` by the build script can invoke the wrong bash shell. The case I've seen is that WSL becomes the default `bash` binary on windows, which will then have issues with the script's line endings, and not find a windows-side `cmake` installation even if you fix the line endings.

Since this can be rather non-obvious, it's worth adding a note to get people unblocked if they run into this.