### PR TITLE
Set relative RPATH to find libimprobable when placed next to the binary

### DIFF
--- a/workers/External/CMakeLists.txt
+++ b/workers/External/CMakeLists.txt
@@ -7,6 +7,7 @@ project(External)
 cmake_minimum_required(VERSION 3.7)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_BUILD_RPATH "$ORIGIN")
 
 set(APPLICATION_ROOT "${PROJECT_SOURCE_DIR}/../..")
 set(SCHEMA_SOURCE_DIR "${APPLICATION_ROOT}/schema")

--- a/workers/Managed/CMakeLists.txt
+++ b/workers/Managed/CMakeLists.txt
@@ -7,6 +7,7 @@ project(Managed)
 cmake_minimum_required(VERSION 3.7)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_BUILD_RPATH "$ORIGIN")
 
 set(APPLICATION_ROOT "${PROJECT_SOURCE_DIR}/../..")
 set(SCHEMA_SOURCE_DIR "${APPLICATION_ROOT}/schema")


### PR DESCRIPTION
A somewhat speculative change to set the RPATH for linux binaries so that they find libimprobable when it's placed next to them in their directory. This is how assemblies are bundled and run in the cloud.
This change is necessary because the project was recently switched over to use dynamic libraries.

I _think_ this change makes sense, and should also be applied to the External worker, but someone with more Linux / CMake knowledge should double-check this.