### PR TITLE
Add .clang-format and re-format worker source

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,156 @@
+---
+Language: Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 100
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '".*"'
+    Priority:        1
+  - Regex:           '^<improbable'
+    Priority:        2
+  - Regex:           '^<.*\.(h|hpp)>'
+    Priority:        3
+  - Regex:           '^<.*>'
+    Priority:        4
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 1
+PenaltyBreakBeforeFirstCallParameter: 10
+PenaltyBreakComment: 400
+PenaltyBreakFirstLessLess: 200
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 50
+PointerAlignment: Left
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+        - 'pb'
+    BasedOnStyle: google
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 2
+UseTab: Never
+---
+Language: Proto
+BasedOnStyle: Google
+ColumnLimit: 100
+---
+Language: Java
+BasedOnStyle: Google
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakAfterJavaFieldAnnotations: true
+BreakStringLiterals: true
+ColumnLimit: 120
+ContinuationIndentWidth: 4
+ExperimentalAutoDetectBinPacking: false
+...

--- a/.clang-format
+++ b/.clang-format
@@ -105,7 +105,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
+Standard: c++14
 TabWidth: 2
 UseTab: Never
 ---

--- a/workers/External/src/startup.cc
+++ b/workers/External/src/startup.cc
@@ -1,12 +1,13 @@
+#include <improbable/standard_library.h>
+#include <improbable/worker.h>
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
-#include <improbable/worker.h>
-#include <improbable/standard_library.h>
 #include <iostream>
 
 // Use this to make a worker::ComponentRegistry. This worker doesn't use any components yet
-// For example use worker::Components<improbable::Position, improbable::Metadata> to track these common components
+// For example use worker::Components<improbable::Position, improbable::Metadata> to track these
+// common components
 using EmptyRegistry = worker::Components<>;
 
 // Constants and parameters
@@ -15,129 +16,133 @@ const std::string kLoggerName = "startup.cc";
 const std::uint32_t kGetOpListTimeoutInMilliseconds = 100;
 
 // Connection helpers
-worker::Connection ConnectWithLocator(const std::string hostname,
-    const std::string login_token,
-    const worker::ConnectionParameters& connection_parameters) {
-    worker::LogsinkParameters logsink_params;
-    logsink_params.Type = worker::LogsinkType::kStdout;
-    logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories, worker::LogLevel level) -> bool {
-        return level >= worker::LogLevel::kWarn ||
-            (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
-    };
-    worker::LocatorParameters locator_parameters;
-    locator_parameters.Logsinks.emplace_back(logsink_params);
-    locator_parameters.PlayerIdentity.LoginToken = login_token;
-    locator_parameters.UseInsecureConnection = true;
+worker::Connection ConnectWithLocator(const std::string hostname, const std::string login_token,
+                                      const worker::ConnectionParameters& connection_parameters) {
+  worker::LogsinkParameters logsink_params;
+  logsink_params.Type = worker::LogsinkType::kStdout;
+  logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories,
+                                                    worker::LogLevel level) -> bool {
+    return level >= worker::LogLevel::kWarn ||
+        (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
+  };
+  worker::LocatorParameters locator_parameters;
+  locator_parameters.Logsinks.emplace_back(logsink_params);
+  locator_parameters.PlayerIdentity.LoginToken = login_token;
+  locator_parameters.UseInsecureConnection = true;
 
-    worker::Locator locator{ hostname, locator_parameters };
+  worker::Locator locator{hostname, locator_parameters};
 
-    auto future = locator.ConnectAsync(EmptyRegistry{}, connection_parameters);
-    return future.Get();
+  auto future = locator.ConnectAsync(EmptyRegistry{}, connection_parameters);
+  return future.Get();
 }
 
-
-worker::Connection ConnectWithReceptionist(const std::string hostname,
-    const std::uint16_t port,
-    const std::string& worker_id,
-    const worker::ConnectionParameters& connection_parameters) {
-    auto future = worker::Connection::ConnectAsync(EmptyRegistry{}, hostname, port, worker_id, connection_parameters);
-    return future.Get();
+worker::Connection
+ConnectWithReceptionist(const std::string hostname, const std::uint16_t port,
+                        const std::string& worker_id,
+                        const worker::ConnectionParameters& connection_parameters) {
+  auto future = worker::Connection::ConnectAsync(EmptyRegistry{}, hostname, port, worker_id,
+                                                 connection_parameters);
+  return future.Get();
 }
 
 std::string get_random_characters(size_t count) {
-    const auto randchar = []() -> char {
-        const char charset[] =
-            "0123456789"
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            "abcdefghijklmnopqrstuvwxyz";
-        const auto max_index = sizeof(charset) - 1;
-        return charset[std::rand() % max_index];
-    };
-    std::string str(count, 0);
-    std::generate_n(str.begin(), count, randchar);
-    return str;
+  const auto randchar = []() -> char {
+    const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    const auto max_index = sizeof(charset) - 1;
+    return charset[std::rand() % max_index];
+  };
+  std::string str(count, 0);
+  std::generate_n(str.begin(), count, randchar);
+  return str;
 }
 
 // Entry point
 int main(int argc, char** argv) {
-    auto now = std::chrono::high_resolution_clock::now();
-    std::srand(std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count());
+  auto now = std::chrono::high_resolution_clock::now();
+  std::srand(
+      std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count());
 
-    auto print_usage = [&]() {
-        std::cout << "Usage: External receptionist <hostname> <port> <worker_id>" << std::endl;
-        std::cout << "       External locator <hostname> <login_token>";
-        std::cout << std::endl;
-        std::cout << "Connects to SpatialOS" << std::endl;
-        std::cout << "    <hostname>       - hostname of the receptionist or locator to connect to.";
-        std::cout << std::endl;
-        std::cout << "    <port>           - port to use if connecting through the receptionist.";
-        std::cout << std::endl;
-        std::cout << "    <worker_id>      - name of the worker assigned by SpatialOS." << std::endl;
-        std::cout << "    <login_token>   - token to use when connecting through the locator.";
-        std::cout << std::endl;
-    };
+  auto print_usage = [&]() {
+    std::cout << "Usage: External receptionist <hostname> <port> <worker_id>" << std::endl;
+    std::cout << "       External locator <hostname> <login_token>";
+    std::cout << std::endl;
+    std::cout << "Connects to SpatialOS" << std::endl;
+    std::cout << "    <hostname>       - hostname of the receptionist or locator to connect to.";
+    std::cout << std::endl;
+    std::cout << "    <port>           - port to use if connecting through the receptionist.";
+    std::cout << std::endl;
+    std::cout << "    <worker_id>      - name of the worker assigned by SpatialOS." << std::endl;
+    std::cout << "    <login_token>   - token to use when connecting through the locator.";
+    std::cout << std::endl;
+  };
 
-    worker::ConnectionParameters parameters;
-    parameters.WorkerType = "External";
-    parameters.Network.ConnectionType = worker::NetworkConnectionType::kKcp;
-    parameters.Network.Kcp.SecurityType = worker::NetworkSecurityType::kInsecure;
-    parameters.Network.UseExternalIp = true;
+  worker::ConnectionParameters parameters;
+  parameters.WorkerType = "External";
+  parameters.Network.ConnectionType = worker::NetworkConnectionType::kKcp;
+  parameters.Network.Kcp.SecurityType = worker::NetworkSecurityType::kInsecure;
+  parameters.Network.UseExternalIp = true;
 
-    worker::LogsinkParameters logsink_params;
-    logsink_params.Type = worker::LogsinkType::kStdout;
-    logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories, worker::LogLevel level) -> bool {
-        return level >= worker::LogLevel::kWarn ||
-            (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
-    };
-    parameters.Logsinks.emplace_back(logsink_params);
-    parameters.EnableLoggingAtStartup = true;
+  worker::LogsinkParameters logsink_params;
+  logsink_params.Type = worker::LogsinkType::kStdout;
+  logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories,
+                                                    worker::LogLevel level) -> bool {
+    return level >= worker::LogLevel::kWarn ||
+        (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
+  };
+  parameters.Logsinks.emplace_back(logsink_params);
+  parameters.EnableLoggingAtStartup = true;
 
-    std::vector<std::string> arguments;
+  std::vector<std::string> arguments;
 
-    // if no arguments are supplied, use the defaults for a local deployment
-    if (argc == 1) {
-        arguments = { "receptionist", "localhost", "7777", parameters.WorkerType + "_" + get_random_characters(4) };
-    } else {
-        arguments = std::vector<std::string>(argv + 1, argv + argc);
-    }
+  // if no arguments are supplied, use the defaults for a local deployment
+  if (argc == 1) {
+    arguments = {"receptionist", "localhost", "7777",
+                 parameters.WorkerType + "_" + get_random_characters(4)};
+  } else {
+    arguments = std::vector<std::string>(argv + 1, argv + argc);
+  }
 
-    const std::string connection_type = arguments[0];
-    if (connection_type != "receptionist" && connection_type != "locator") {
-        print_usage();
-        return ErrorExitStatus;
-    }
-
-    const bool use_locator = connection_type == "locator";
-
-    if ((use_locator && arguments.size() != 5) || (!use_locator && arguments.size() != 4)) {
-        print_usage();
-        return ErrorExitStatus;
-    }
-
-    // Connect with locator or receptionist
-    worker::Connection connection = use_locator
-        ? ConnectWithLocator(arguments[1], arguments[2], parameters)
-        : ConnectWithReceptionist(arguments[1], atoi(arguments[2].c_str()), arguments[3], parameters);
-
-    if (connection.GetConnectionStatusCode() != worker::ConnectionStatusCode::kSuccess) {
-        std::cerr << "Worker connection failed: " << connection.GetConnectionStatusDetailString() << std::endl;
-        return 1;
-    }
-
-    connection.SendLogMessage(worker::LogLevel::kInfo, kLoggerName, "Connected successfully");
-
-    // Register callbacks and run the worker main loop.
-    worker::Dispatcher dispatcher{ EmptyRegistry{} };
-    
-    bool is_connected = true;
-    dispatcher.OnDisconnect([&](const worker::DisconnectOp& op) {
-        std::cerr << "[disconnect] " << op.Reason << std::endl;
-        is_connected = false;
-    });
-
-    while (is_connected) {
-        dispatcher.Process(connection.GetOpList(kGetOpListTimeoutInMilliseconds));
-    }
-
+  const std::string connection_type = arguments[0];
+  if (connection_type != "receptionist" && connection_type != "locator") {
+    print_usage();
     return ErrorExitStatus;
+  }
+
+  const bool use_locator = connection_type == "locator";
+
+  if ((use_locator && arguments.size() != 5) || (!use_locator && arguments.size() != 4)) {
+    print_usage();
+    return ErrorExitStatus;
+  }
+
+  // Connect with locator or receptionist
+  worker::Connection connection = use_locator
+      ? ConnectWithLocator(arguments[1], arguments[2], parameters)
+      : ConnectWithReceptionist(arguments[1], atoi(arguments[2].c_str()), arguments[3], parameters);
+
+  if (connection.GetConnectionStatusCode() != worker::ConnectionStatusCode::kSuccess) {
+    std::cerr << "Worker connection failed: " << connection.GetConnectionStatusDetailString()
+              << std::endl;
+    return 1;
+  }
+
+  connection.SendLogMessage(worker::LogLevel::kInfo, kLoggerName, "Connected successfully");
+
+  // Register callbacks and run the worker main loop.
+  worker::Dispatcher dispatcher{EmptyRegistry{}};
+
+  bool is_connected = true;
+  dispatcher.OnDisconnect([&](const worker::DisconnectOp& op) {
+    std::cerr << "[disconnect] " << op.Reason << std::endl;
+    is_connected = false;
+  });
+
+  while (is_connected) {
+    dispatcher.Process(connection.GetOpList(kGetOpListTimeoutInMilliseconds));
+  }
+
+  return ErrorExitStatus;
 }

--- a/workers/Managed/src/startup.cc
+++ b/workers/Managed/src/startup.cc
@@ -14,7 +14,9 @@
 
 // This keeps track of all components and component sets that this worker uses.
 // Used to make a worker::ComponentRegistry.
-using ComponentRegistry = worker::Schema<sample::LoginListenerSet, sample::PositionSet, improbable::Position, improbable::restricted::Worker, improbable::restricted::Partition>;
+using ComponentRegistry =
+    worker::Schema<sample::LoginListenerSet, sample::PositionSet, improbable::Position,
+                   improbable::restricted::Worker, improbable::restricted::Partition>;
 
 // Constants and parameters
 const int ErrorExitStatus = 1;
@@ -24,146 +26,155 @@ const std::uint32_t kGetOpListTimeoutInMilliseconds = 100;
 const worker::EntityId listenerEntity = 1;
 const worker::EntityId serverPartitionId = 2;
 
-worker::Connection ConnectWithReceptionist(const std::string hostname,
-                                           const std::uint16_t port,
-                                           const std::string& worker_id,
-                                           const worker::ConnectionParameters& connection_parameters) {
-    auto future = worker::Connection::ConnectAsync(ComponentRegistry{}, hostname, port, worker_id, connection_parameters);
-    return future.Get();
+worker::Connection
+ConnectWithReceptionist(const std::string hostname, const std::uint16_t port,
+                        const std::string& worker_id,
+                        const worker::ConnectionParameters& connection_parameters) {
+  auto future = worker::Connection::ConnectAsync(ComponentRegistry{}, hostname, port, worker_id,
+                                                 connection_parameters);
+  return future.Get();
 }
 
 std::string get_random_characters(size_t count) {
-    const auto randchar = []() -> char {
-        const char charset[] =
-            "0123456789"
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            "abcdefghijklmnopqrstuvwxyz";
-        const auto max_index = sizeof(charset) - 1;
-        return charset[std::rand() % max_index];
-    };
-    std::string str(count, 0);
-    std::generate_n(str.begin(), count, randchar);
-    return str;
+  const auto randchar = []() -> char {
+    const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    const auto max_index = sizeof(charset) - 1;
+    return charset[std::rand() % max_index];
+  };
+  std::string str(count, 0);
+  std::generate_n(str.begin(), count, randchar);
+  return str;
 }
 
 // Entry point
-int main(int argc, char** argv)
-{
-    auto now = std::chrono::high_resolution_clock::now();
-    std::srand(std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count());
+int main(int argc, char** argv) {
+  auto now = std::chrono::high_resolution_clock::now();
+  std::srand(
+      std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count());
 
-    std::cout << "[local] Worker started " << std::endl;
+  std::cout << "[local] Worker started " << std::endl;
 
-    auto print_usage = [&]() {
-        std::cout << "Usage: Managed receptionist <hostname> <port> <worker_id>" << std::endl;
-        std::cout << std::endl;
-        std::cout << "Connects to SpatialOS" << std::endl;
-        std::cout << "    <hostname>      - hostname of the receptionist or locator to connect to.";
-        std::cout << std::endl;
-        std::cout << "    <port>          - port to use if connecting through the receptionist.";
-        std::cout << std::endl;
-        std::cout << "    <worker_id>     - (optional) name of the worker assigned by SpatialOS." << std::endl;
-        std::cout << std::endl;
-    };
+  auto print_usage = [&]() {
+    std::cout << "Usage: Managed receptionist <hostname> <port> <worker_id>" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Connects to SpatialOS" << std::endl;
+    std::cout << "    <hostname>      - hostname of the receptionist or locator to connect to.";
+    std::cout << std::endl;
+    std::cout << "    <port>          - port to use if connecting through the receptionist.";
+    std::cout << std::endl;
+    std::cout << "    <worker_id>     - (optional) name of the worker assigned by SpatialOS."
+              << std::endl;
+    std::cout << std::endl;
+  };
 
-    std::vector<std::string> arguments;
+  std::vector<std::string> arguments;
 
-    // if no arguments are supplied, use the defaults for a local deployment
-    if (argc == 1) {
-        arguments = { "receptionist", "localhost", "7777" };
-    } else {
-        arguments = std::vector<std::string>(argv + 1, argv + argc);
-    }
+  // if no arguments are supplied, use the defaults for a local deployment
+  if (argc == 1) {
+    arguments = {"receptionist", "localhost", "7777"};
+  } else {
+    arguments = std::vector<std::string>(argv + 1, argv + argc);
+  }
 
-    if (arguments.size() != 4 && arguments.size() != 3) {
-        print_usage();
-        return ErrorExitStatus;
-    }
+  if (arguments.size() != 4 && arguments.size() != 3) {
+    print_usage();
+    return ErrorExitStatus;
+  }
 
-    worker::ConnectionParameters parameters;
-    parameters.WorkerType = "Managed";
-    parameters.Network.ConnectionType = worker::NetworkConnectionType::kTcp;
-    parameters.Network.Tcp.SecurityType = worker::NetworkSecurityType::kInsecure;
-    parameters.Network.UseExternalIp = false;
+  worker::ConnectionParameters parameters;
+  parameters.WorkerType = "Managed";
+  parameters.Network.ConnectionType = worker::NetworkConnectionType::kTcp;
+  parameters.Network.Tcp.SecurityType = worker::NetworkSecurityType::kInsecure;
+  parameters.Network.UseExternalIp = false;
 
-    worker::LogsinkParameters logsink_params;
-    logsink_params.Type = worker::LogsinkType::kStdout;
-    logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories, worker::LogLevel level) -> bool {
-        return level >= worker::LogLevel::kWarn ||
-            (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
-    };
-    parameters.Logsinks.emplace_back(logsink_params);
-    parameters.EnableLoggingAtStartup = true;
+  worker::LogsinkParameters logsink_params;
+  logsink_params.Type = worker::LogsinkType::kStdout;
+  logsink_params.FilterParameters.CustomFilter = [](worker::LogCategory categories,
+                                                    worker::LogLevel level) -> bool {
+    return level >= worker::LogLevel::kWarn ||
+        (level >= worker::LogLevel::kInfo && categories & worker::LogCategory::kLogin);
+  };
+  parameters.Logsinks.emplace_back(logsink_params);
+  parameters.EnableLoggingAtStartup = true;
 
-    std::string workerId;
+  std::string workerId;
 
-    // When running as an external worker using 'spatial local worker launch'
-    // The WorkerId isn't passed, so we generate a random one
-    if (arguments.size() == 4) {
-        workerId = arguments[3];
-    } else {
-        workerId = parameters.WorkerType + "_" + get_random_characters(4);
-    }
+  // When running as an external worker using 'spatial local worker launch'
+  // The WorkerId isn't passed, so we generate a random one
+  if (arguments.size() == 4) {
+    workerId = arguments[3];
+  } else {
+    workerId = parameters.WorkerType + "_" + get_random_characters(4);
+  }
 
-    std::cout << "[local] Connecting to SpatialOS as " << workerId << "..." << std::endl;
+  std::cout << "[local] Connecting to SpatialOS as " << workerId << "..." << std::endl;
 
-    // Connect with receptionist
-    worker::Connection connection = ConnectWithReceptionist(arguments[1], atoi(arguments[2].c_str()), workerId, parameters);
+  // Connect with receptionist
+  worker::Connection connection =
+      ConnectWithReceptionist(arguments[1], atoi(arguments[2].c_str()), workerId, parameters);
 
-    if (connection.GetConnectionStatusCode() != worker::ConnectionStatusCode::kSuccess) {
-        std::cerr << "Worker connection failed: " << connection.GetConnectionStatusDetailString() << std::endl;
-        return 1;
-    }
+  if (connection.GetConnectionStatusCode() != worker::ConnectionStatusCode::kSuccess) {
+    std::cerr << "Worker connection failed: " << connection.GetConnectionStatusDetailString()
+              << std::endl;
+    return 1;
+  }
 
-    connection.SendLogMessage(worker::LogLevel::kInfo, kLoggerName, "Connected successfully");
+  connection.SendLogMessage(worker::LogLevel::kInfo, kLoggerName, "Connected successfully");
 
-    worker::View view{ComponentRegistry{}};
+  worker::View view{ComponentRegistry{}};
 
-    bool is_connected = true;
-    view.OnDisconnect([&](const worker::DisconnectOp& op) {
-        std::cerr << "[disconnect] " << op.Reason << std::endl;
-        is_connected = false;
-    });
+  bool is_connected = true;
+  view.OnDisconnect([&](const worker::DisconnectOp& op) {
+    std::cerr << "[disconnect] " << op.Reason << std::endl;
+    is_connected = false;
+  });
 
-    using AssignPartitionCommand = improbable::restricted::Worker::Commands::AssignPartition;
+  using AssignPartitionCommand = improbable::restricted::Worker::Commands::AssignPartition;
 
-    // In real code, we would probably want to retry here.
-    view.OnCommandResponse<AssignPartitionCommand>(
-        [&](const worker::CommandResponseOp<AssignPartitionCommand>& op) {
-            if (op.StatusCode == worker::StatusCode::kSuccess) {
-                connection.SendLogMessage(worker::LogLevel::kInfo, "Server",
+  // In real code, we would probably want to retry here.
+  view.OnCommandResponse<AssignPartitionCommand>(
+      [&](const worker::CommandResponseOp<AssignPartitionCommand>& op) {
+        if (op.StatusCode == worker::StatusCode::kSuccess) {
+          connection.SendLogMessage(worker::LogLevel::kInfo, "Server",
                                     "Successfully assigned partition.");
-            } else {
-                connection.SendLogMessage(worker::LogLevel::kError, "Server",
+        } else {
+          connection.SendLogMessage(worker::LogLevel::kError, "Server",
                                     "Failed to assign partition: error code : " +
                                         std::to_string(static_cast<std::uint8_t>(op.StatusCode)) +
                                         " message: " + op.Message);
-            }
-        });
-
-    connection.SendCommandRequest<AssignPartitionCommand>(connection.GetWorkerEntityId(), {serverPartitionId}, /* default timeout */ {});
-
-    view.OnAddComponent<improbable::restricted::Worker>([&](worker::AddComponentOp<improbable::restricted::Worker> op)
-    {
-        connection.SendLogMessage(worker::LogLevel::kInfo, "Server", "Worker with ID " + op.Data.worker_id() + " connected.");
-    });
-
-    double elapsed_time = 0.0;
-    auto last_tick_time = std::chrono::steady_clock::now();
-
-    while (is_connected) {
-        view.Process(connection.GetOpList(kGetOpListTimeoutInMilliseconds));
-
-        if (view.GetAuthority<sample::LoginListenerSet>(listenerEntity) == worker::Authority::kAuthoritative) {
-            improbable::Position::Update pos_update;
-            pos_update.set_coords({std::sin(elapsed_time), 0.0, std::cos(elapsed_time)});
-            connection.SendComponentUpdate<improbable::Position>(listenerEntity, pos_update);
         }
+      });
 
-        auto now = std::chrono::steady_clock::now();
-        elapsed_time += std::chrono::duration<double>(now - last_tick_time).count(); // Amount of time since last tick, in seconds
-        last_tick_time = now;
+  connection.SendCommandRequest<AssignPartitionCommand>(
+      connection.GetWorkerEntityId(), {serverPartitionId}, /* default timeout */ {});
+
+  view.OnAddComponent<improbable::restricted::Worker>(
+      [&](worker::AddComponentOp<improbable::restricted::Worker> op) {
+        connection.SendLogMessage(worker::LogLevel::kInfo, "Server",
+                                  "Worker with ID " + op.Data.worker_id() + " connected.");
+      });
+
+  double elapsed_time = 0.0;
+  auto last_tick_time = std::chrono::steady_clock::now();
+
+  while (is_connected) {
+    view.Process(connection.GetOpList(kGetOpListTimeoutInMilliseconds));
+
+    if (view.GetAuthority<sample::LoginListenerSet>(listenerEntity) ==
+        worker::Authority::kAuthoritative) {
+      improbable::Position::Update pos_update;
+      pos_update.set_coords({std::sin(elapsed_time), 0.0, std::cos(elapsed_time)});
+      connection.SendComponentUpdate<improbable::Position>(listenerEntity, pos_update);
     }
 
-    return ErrorExitStatus;
+    auto now = std::chrono::steady_clock::now();
+    elapsed_time += std::chrono::duration<double>(now - last_tick_time)
+                        .count();  // Amount of time since last tick, in seconds
+    last_tick_time = now;
+  }
+
+  return ErrorExitStatus;
 }


### PR DESCRIPTION
Formatted with clang-format version 10.0.0 on windows.
I ran `clang-format -i <file>` on both worker's startup.cc files, which are the only C++ source files in this project.

I've copied the .clang-format file from https://github.com/spatialos/CExampleProject/blob/master/.clang-format, with one change of making the language version be c++14